### PR TITLE
chore: filter unactionable Sentry noise (extension + SW prerender)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -43,6 +43,17 @@ Sentry.init({
   enableLogs: true,
   replaysSessionSampleRate: 0.1,
   replaysOnErrorSampleRate: 1.0,
+  ignoreErrors: [
+    // Browser-extension content scripts inject WebExtension messaging into
+    // the page; their failures are not our code and are unfixable here.
+    // Sentry TIM-DOT-CODES-6.
+    /runtime\.sendMessage/,
+    // vite-plugin-pwa's injected SW registration throws InvalidStateError
+    // when Chrome registers during prerender. No elegant in-plugin or
+    // newer-version fix exists, so we filter the noise. Sentry
+    // TIM-DOT-CODES-5.
+    /Failed to register a ServiceWorker/,
+  ],
 })
 
 const pinia = createPinia()


### PR DESCRIPTION
## Summary

Triaged the two open Sentry issues for `tim-dot-codes`. Both are rare, environmental, and not fixable in our code, so both are silenced via Sentry `ignoreErrors` rather than worked around.

- **TIM-DOT-CODES-6** — `runtime.sendMessage()` failures come from browser-extension content scripts injected into the page; not our code, unfixable here. Filtered; also marked ignored (Forever) in the Sentry dashboard.
- **TIM-DOT-CODES-5** — `vite-plugin-pwa`'s injected SW registration throws `InvalidStateError` when Chrome registers during prerender. An earlier revision hand-rolled a guarded replacement; per review that was reverted (no elegant in-plugin fix exists — error handling requires `virtual:pwa-register`, i.e. replacing the injected script; and no newer-version fix — 1.3.0 only adds Vite 8 + `onNeedReload`). SW registration is unchanged from the plugin default; the error is filtered the same way as -6.

Net change: two regexes added to `Sentry.init({ ignoreErrors })`. No behavior change.

## Test Plan

- [x] `yarn ci:unit` — pass
- [x] `yarn lint:eslint` / `yarn lint:knip` — clean
- [x] `yarn type-check` — no errors in changed files (pre-existing `*.vue` cold-cache errors unrelated)
- [x] `yarn build-only` — succeeds; plugin's `registerSW.js` re-injected as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)