### PR TITLE
fix(ci): install Playwright browsers via Yarn, not npx

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,11 @@ jobs:
     - name: Install dependencies
       run: yarn install
     - name: Install Playwright browsers
-      run: npx playwright install --with-deps
+      # Use Yarn (not npx) so the project-pinned Playwright resolves through
+      # Yarn 4's dependency graph and installs browser builds matching
+      # @playwright/test's expected version. `npx playwright` fetches a
+      # different registry version and installs mismatched builds.
+      run: yarn playwright install --with-deps
     - name: Build project
       run: yarn build
     - name: Run E2E tests


### PR DESCRIPTION
## Summary

CI's **End-to-End Tests** job has been failing on `master` (and was the only red check on #18). Root-caused via the failed-run logs:

- All 6 E2E failures are identical: `browserType.launch: Executable doesn't exist at .../webkit-2272/pw_run.sh` — a browser-binary version mismatch, not a test-logic failure. Unit + Lint pass.
- Install step logs Playwright's warning: *"running 'npx playwright install' without first installing your project's dependencies"*.
- This repo uses **Yarn 4 / Corepack**. `npx playwright install` does not resolve the project-pinned `playwright-core@1.59.1` through Yarn's dependency graph — it fetches a different registry version and installs mismatched browser builds. `@playwright/test@1.59.1` then can't find its expected `webkit-2272` build.
- Latent since the workflow adopted `npx`; surfaced when the `c19827c` "Update deps" commit diverged the npx-resolved vs project Playwright versions (that commit never had its own CI run).

**Not related to PR #18** (Sentry `ignoreErrors` regexes — no path to Playwright binaries).

## Fix

`npx playwright install --with-deps` → `yarn playwright install --with-deps`, so the project's exact pinned Playwright installs the matching browser builds.

## Test Plan

- [ ] This PR's **End-to-End Tests** job goes green (the failing job *is* the test for this fix)
- [ ] Unit Tests / Linters remain green

🤖 Generated with [Claude Code](https://claude.com/claude-code)