### PR TITLE
test(e2e): use stable testids for header contrast locators

### DIFF
--- a/e2e/contrast.spec.ts
+++ b/e2e/contrast.spec.ts
@@ -43,17 +43,17 @@ function worstContrast(cssColor: string, section: NeonSection): number {
 for (const { hash, section } of routes) {
   test(`header text meets WCAG AA on ${section}`, async ({ page }) => {
     await page.goto(`/${hash}`)
-    await page.locator('header h1').waitFor()
+    await page.getByTestId('site-title').waitFor()
 
     // Large bold title — WCAG AA large-text threshold is 3:1.
     const titleColor = await page
-      .locator('header h1')
+      .getByTestId('site-title')
       .evaluate((el) => getComputedStyle(el).color)
     expect(worstContrast(titleColor, section)).toBeGreaterThanOrEqual(3)
 
     // Small bold nav labels — WCAG AA normal-text threshold is 4.5:1.
     const labelColors = await page
-      .locator('header .tab-label')
+      .getByTestId('nav-tab-label')
       .evaluateAll((els) => els.map((el) => getComputedStyle(el).color))
     expect(labelColors.length).toBeGreaterThan(0)
     for (const color of labelColors) {

--- a/src/components/NavigationView.vue
+++ b/src/components/NavigationView.vue
@@ -1,7 +1,7 @@
 <template>
   <header :class="String(route.name)">
     <div class="header-content">
-      <h1>Tim Morgan</h1>
+      <h1 data-testid="site-title">Tim Morgan</h1>
       <nav :aria-label="t('header.nav')">
         <ul role="tablist">
           <li id="home-tab" role="tab" :class="{ active: route.name === 'bio' }">
@@ -12,7 +12,7 @@
               @click.prevent="navigate({ name: 'bio' })"
             >
               <home-image id="home-image" />
-              <span class="tab-label">{{ t('header.links.home') }}</span>
+              <span class="tab-label" data-testid="nav-tab-label">{{ t('header.links.home') }}</span>
             </a>
           </li>
           <li id="projects-tab" role="tab" :class="{ active: route.name === 'projects' }">
@@ -23,7 +23,7 @@
               @click.prevent="navigate({ name: 'projects' })"
             >
               <projects-image id="projects-image" />
-              <span class="tab-label">{{ t('header.links.projects') }}</span>
+              <span class="tab-label" data-testid="nav-tab-label">{{ t('header.links.projects') }}</span>
             </a>
           </li>
           <li id="resume-tab" role="tab" :class="{ active: route.name === 'resume' }">
@@ -34,7 +34,7 @@
               @click.prevent="navigate({ name: 'resume' })"
             >
               <resume-image id="resume-image" />
-              <span class="tab-label">{{ t('header.links.resume') }}</span>
+              <span class="tab-label" data-testid="nav-tab-label">{{ t('header.links.resume') }}</span>
             </a>
           </li>
         </ul>


### PR DESCRIPTION
## Summary

Hardens the WCAG contrast e2e spec against markup/restyling churn by replacing CSS-structure locators with stable test IDs.

## Findings addressed

- **Finding 1 (locator resilience — `e2e/contrast.spec.ts`)**: The spec selected header text via CSS structure (`header h1`, `header .tab-label`), which restyling or markup changes would silently break. Added `data-testid="site-title"` to the `<h1>` site title and `data-testid="nav-tab-label"` to each nav tab-label `<span>` in `src/components/NavigationView.vue`, and switched the spec to `getByTestId('site-title')` / `getByTestId('nav-tab-label')`. The test IDs were verified to render (the contrast assertions located and evaluated the elements during the full Playwright run).

## Findings deferred

- **Finding 2 (POM style — `e2e/pages/BasePage.ts` + `ProjectsPage.ts`)**: Left as-is. This was flagged as stylistic-only. The existing page object already uses resilient `getByRole` locators (no CSS chains or positional selectors), is injected via a Playwright fixture (`e2e/fixtures/index.ts`), and is shared by the navigation specs — matching the guidance for a screen-level page object that multiple specs touch. Simplifying it would be a churny refactor of already-green, already-conformant code with no test-resilience benefit, so it was intentionally not changed.

## Verification

- `pnpm type-check` (vue-tsc): passed
- `pnpm lint` (oxlint + eslint + stylelint + knip): exit 0
- `pnpm ci:unit` (vitest): 26 passed
- `npx playwright test --list`: 15 tests compile
- `npx playwright test` (full run, webServer auto-started): 15 passed across chromium, firefox, webkit

🤖 Generated with [Claude Code](https://claude.com/claude-code)