### PR TITLE
test(e2e): use stable testids for header contrast locators

### DIFF
--- a/e2e/contrast.spec.ts
+++ b/e2e/contrast.spec.ts
@@ -43,17 +43,17 @@ function worstContrast(cssColor: string, section: NeonSection): number {
 for (const { hash, section } of routes) {
   test(`header text meets WCAG AA on ${section}`, async ({ page }) => {
     await page.goto(`/${hash}`)
-    await page.locator('header h1').waitFor()
+    await page.getByTestId('site-title').waitFor()
 
     // Large bold title — WCAG AA large-text threshold is 3:1.
     const titleColor = await page
-      .locator('header h1')
+      .getByTestId('site-title')
       .evaluate((el) => getComputedStyle(el).color)
     expect(worstContrast(titleColor, section)).toBeGreaterThanOrEqual(3)
 
     // Small bold nav labels — WCAG AA normal-text threshold is 4.5:1.
     const labelColors = await page
-      .locator('header .tab-label')
+      .getByTestId('nav-tab-label')
       .evaluateAll((els) => els.map((el) => getComputedStyle(el).color))
     expect(labelColors.length).toBeGreaterThan(0)
     for (const color of labelColors) {

--- a/src/components/NavigationView.vue
+++ b/src/components/NavigationView.vue
@@ -1,7 +1,7 @@
 <template>
   <header :class="String(route.name)">
     <div class="header-content">
-      <h1>Tim Morgan</h1>
+      <h1 data-testid="site-title">Tim Morgan</h1>
       <nav :aria-label="t('header.nav')">
         <ul role="tablist">
           <li id="home-tab" role="tab" :class="{ active: route.name === 'bio' }">
@@ -12,7 +12,9 @@
               @click.prevent="navigate({ name: 'bio' })"
             >
               <home-image id="home-image" />
-              <span class="tab-label">{{ t('header.links.home') }}</span>
+              <span class="tab-label" data-testid="nav-tab-label">{{
+                t('header.links.home')
+              }}</span>
             </a>
           </li>
           <li id="projects-tab" role="tab" :class="{ active: route.name === 'projects' }">
@@ -23,7 +25,9 @@
               @click.prevent="navigate({ name: 'projects' })"
             >
               <projects-image id="projects-image" />
-              <span class="tab-label">{{ t('header.links.projects') }}</span>
+              <span class="tab-label" data-testid="nav-tab-label">{{
+                t('header.links.projects')
+              }}</span>
             </a>
           </li>
           <li id="resume-tab" role="tab" :class="{ active: route.name === 'resume' }">
@@ -34,7 +38,9 @@
               @click.prevent="navigate({ name: 'resume' })"
             >
               <resume-image id="resume-image" />
-              <span class="tab-label">{{ t('header.links.resume') }}</span>
+              <span class="tab-label" data-testid="nav-tab-label">{{
+                t('header.links.resume')
+              }}</span>
             </a>
           </li>
         </ul>


### PR DESCRIPTION
## Summary

Resolves the locator-resilience finding in the WCAG contrast e2e spec so the suite no longer depends on header markup/CSS structure.

## Findings addressed

- **Finding 1 — locator resilience (priority):** `e2e/contrast.spec.ts` selected header text via CSS structure (`header h1`, `header .tab-label`), which a restyle or markup change would silently break. Added `data-testid="site-title"` to the `<h1>` site title and `data-testid="nav-tab-label"` to each nav tab label in `src/components/NavigationView.vue`, and switched the spec to `page.getByTestId(...)`. The testids are added to the real Vue SFC source and verified to render via a passing e2e run.

## Findings deferred

- **Finding 2 — POM style (`e2e/pages/BasePage.ts`, `ProjectsPage.ts`):** Left as-is, intentionally. The page objects already follow the target guidance: lifecycle is owned by a Playwright fixture (`e2e/fixtures/index.ts` injects `projectsPage` per test via `test.extend`), locators use resilient `getByRole`, and the methods are thin single-action helpers whose only role is acting (specs keep the feature assertions). Rewriting them would be a lateral stylistic change with no clear improvement and some risk, so per the guidance ("only simplify if clearly low-risk and an improvement; otherwise leave it") it is deferred.

## Verification

All run locally against Node 26.3.0 / pnpm 11.5.1:

- `pnpm run lint` (oxlint + eslint + stylelint + knip) — pass (exit 0; only pre-existing knip config hints)
- `pnpm run type-check` (`vue-tsc --build`) — pass
- `pnpm run ci:unit` (vitest) — 26/26 pass
- `npx playwright test --list` — 15 specs compile
- `npx playwright test` (full suite, webServer auto-built) — **15/15 pass** across chromium, firefox, and webkit, confirming the new testids render and the `getByTestId` locators resolve end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)